### PR TITLE
Update uniacc2entrezid.py

### DIFF
--- a/utils/uniacc2entrezid.py
+++ b/utils/uniacc2entrezid.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import click
+import json
 import re
 import ssl
 from urllib import parse, request
@@ -25,14 +26,22 @@ def cli(**params):
 
 def __get_uniaccs_entrezids(uniaccs):
 
+
+    return(uniaccs_entrezids)
+
+def __get_uniaccs_entrezids(uniaccs):
+
     # Initialize
     uniaccs_entrezids = []
     gcontext = ssl.SSLContext()
-    url = "https://www.uniprot.org/uploadlists/"
+    #url = "https://www.uniprot.org/uploadlists/"
+    url = "https://rest.uniprot.org/idmapping/run"
     params = {
-        "from": "ACC+ID",
-        "to": "P_ENTREZGENEID",
-        "format": "tab",
+        #"from": "ACC+ID",
+        "from": "UniProtKB_AC-ID",
+        #"to": "P_ENTREZGENEID",
+        "to": "GeneID",
+        #"format": "tab",
         "query": " ".join(list(uniaccs))
     }
 
@@ -41,11 +50,21 @@ def __get_uniaccs_entrezids(uniaccs):
     req = request.Request(url, params)
     with request.urlopen(req, context=gcontext) as handle:
         response = handle.read().decode("utf-8")
-    for line in response.split("\n"):
-        m = re.search("(\w+)\t(\d+)", line)
-        if m:
-            uniacc, entrezid = line.split("\t")
-            uniaccs_entrezids.append([uniacc, int(entrezid)])
+        response = json.loads(response)
+        jobid = response["jobId"]
+    url_jobid = f"https://rest.uniprot.org/idmapping/results/{jobid}"
+    req_jobid = request.Request(url_jobid)
+    with request.urlopen(req_jobid, context=gcontext) as handle:
+        result = handle.read().decode("utf-8")
+        result = json.loads(result)
+    #for line in response.split("\n"):
+    #    m = re.search("(\w+)\t(\d+)", line)
+    #    if m:
+    #        uniacc, entrezid = line.split("\t")
+    #        uniaccs_entrezids.append([uniacc, int(entrezid)])
+    for r in result["results"]:
+        if "to" in r.keys():
+            uniaccs_entrezids.append([r["from"], int(r["to"])])
 
     return(uniaccs_entrezids)
 


### PR DESCRIPTION
Changes suggested by Ieva Rauluseviciute: "UniProt has updated their API in 2022 October. This means that the way Entrez IDs were retrieved is not working anymore. We found a way to update the function to accommodate the updated API."